### PR TITLE
Handle non image raw uploads and bump version to 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 As of 2.0.0, this project adheres to [Semantic Versioning](http://semver.org/) and the format is based on the suggestions a <http://keepachangelog.com/>.
 
+## [2.0.1] - 2017-10-19
+### Fixed
+- Uploading non-image files to the raw endpoint failed with a `400 Bad Request` error. (Ticket #23) 
+
 ## [2.0.0] - 2016-10-16
 ### Added
 - A new example showing how to create a gallery and upload an image to it.

--- a/lib/phpZenfolio/Client.php
+++ b/lib/phpZenfolio/Client.php
@@ -14,7 +14,7 @@ class Client
     /**
      * A few default variables.
      */
-    const VERSION = '2.0.0';
+    const VERSION = '2.0.1';
     public $AppName = 'Unknown Application';
     protected $authToken;
     private $keyring;

--- a/lib/phpZenfolio/Client.php
+++ b/lib/phpZenfolio/Client.php
@@ -220,7 +220,6 @@ class Client
     public function upload($photoSet, $file, $args = array())
     {
         if (is_file($file)) {
-            $fileinfo = getimagesize($file); // We need this to get the content type.
             $fp = fopen($file, 'rb');
             $data = fread($fp, filesize($file));
             fclose($fp);
@@ -244,7 +243,7 @@ class Client
         $this->client = self::getHttpClient();
 
         // Required headers
-        $this->request_options['headers']['Content-Type'] = $fileinfo['mime'];
+        $this->request_options['headers']['Content-Type'] = mime_content_type($file);
         $this->request_options['headers']['Content-Length'] = filesize($file);
 
         if (!is_null($this->authToken)) {

--- a/test/phpZenfolio/Tests/ClientTest.php
+++ b/test/phpZenfolio/Tests/ClientTest.php
@@ -348,7 +348,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
           new Response(200, []),  // Upload using photoset object
           new Response(200, [], $this->fauxPhotoSetObjectResponse), // LoadPhotoSet() called when using photoset ID for upload
           new Response(200, []), // Upload using photoset ID
-          new Response(200, []), // Upload raw for non-image type using photoset ID
+          new Response(200, []), // Upload raw for non-image type using photoset object
           new Response(200, []), // Upload using upload URL
       ]);
 

--- a/test/phpZenfolio/Tests/ClientTest.php
+++ b/test/phpZenfolio/Tests/ClientTest.php
@@ -348,6 +348,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
           new Response(200, []),  // Upload using photoset object
           new Response(200, [], $this->fauxPhotoSetObjectResponse), // LoadPhotoSet() called when using photoset ID for upload
           new Response(200, []), // Upload using photoset ID
+          new Response(200, []), // Upload raw for non-image type using photoset ID
           new Response(200, []), // Upload using upload URL
       ]);
 
@@ -379,6 +380,13 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('modified', $request_options['query']);
         $this->assertEquals($mod_date, $request_options['query']['modified']);
 
+      // Upload raw for non-image type using photoset object
+      $client->upload(json_decode($this->fauxPhotoSetObjectResponse)->result, './README.md', ['type' => 'raw']);
+      // Confirm the content type
+      $request_options = $client->getRequestOptions();
+        $this->assertArrayHasKey('Content-Type', $request_options['headers']);
+        $this->assertEquals('text/plain', $request_options['headers']['Content-Type']);
+
       // Upload by photoset URL
       $client->upload(json_decode($this->fauxPhotoSetObjectResponse)->result->UploadUrl, './examples/phpZenfolio-logo.png');
         $request_options = $client->getRequestOptions();
@@ -401,8 +409,12 @@ class ClientTest extends \PHPUnit_Framework_TestCase
                   $this->assertEquals(json_decode($this->fauxPhotoSetObjectResponse)->result->RawUploadUrl, $url->getScheme().'://'.$url->getHost().$url->getPath());
                   $this->assertEquals('filename=newfilename.png&modified='.rawurlencode($mod_date), $query);
               break;
-
               case 3:
+                  // Raw upload URL for non-photo file
+                  $this->assertEquals(json_decode($this->fauxPhotoSetObjectResponse)->result->RawUploadUrl, $url->getScheme().'://'.$url->getHost().$url->getPath());
+                  $this->assertEquals('filename=README.md', $query);
+              break;
+              case 4:
                   // Upload url
                   $this->assertEquals(json_decode($this->fauxPhotoSetObjectResponse)->result->UploadUrl, $url->getScheme().'://'.$url->getHost().$url->getPath());
                   $this->assertEquals('filename=phpZenfolio-logo.png', $query);

--- a/test/phpZenfolio/Tests/ClientZenfolioTest.php
+++ b/test/phpZenfolio/Tests/ClientZenfolioTest.php
@@ -84,7 +84,7 @@ class ClientZenfolioTest extends \PHPUnit_Framework_TestCase
      */
     public function shouldUploadToPhotoSet($photoSetObject)
     {
-        $response = $this->client->upload($photoSetObject, 'README.md');
+        $response = $this->client->upload($photoSetObject, 'README.md', ['type' => 'raw']);
         $this->assertTrue(is_int($response));
 
         $response = $this->client->upload($photoSetObject, 'examples/phpZenfolio-logo.png');

--- a/test/phpZenfolio/Tests/ClientZenfolioTest.php
+++ b/test/phpZenfolio/Tests/ClientZenfolioTest.php
@@ -85,7 +85,7 @@ class ClientZenfolioTest extends \PHPUnit_Framework_TestCase
     public function shouldUploadToPhotoSet($photoSetObject)
     {
         $response = $this->client->upload($photoSetObject, 'README.md', ['type' => 'raw']);
-        $this->assertTrue(is_int($response));
+        $this->assertTrue(empty($response));
 
         $response = $this->client->upload($photoSetObject, 'examples/phpZenfolio-logo.png');
         $this->assertTrue(is_int($response));

--- a/test/phpZenfolio/Tests/ClientZenfolioTest.php
+++ b/test/phpZenfolio/Tests/ClientZenfolioTest.php
@@ -80,10 +80,13 @@ class ClientZenfolioTest extends \PHPUnit_Framework_TestCase
      * @test
      * @depends shouldCreateNewPhotoSet
      *
-     * Tests adding a photo to a photoset
+     * Tests adding a photo & non-photo file to a photoset
      */
     public function shouldUploadToPhotoSet($photoSetObject)
     {
+        $response = $this->client->upload($photoSetObject, 'README.md');
+        $this->assertTrue(is_int($response));
+
         $response = $this->client->upload($photoSetObject, 'examples/phpZenfolio-logo.png');
         $this->assertTrue(is_int($response));
 


### PR DESCRIPTION
As pointed out in https://github.com/lildude/phpZenfolio/issues/23, uploading non-image files to the raw endpoint fails with a `400 Bad Request` error.

This is happening because phpZenfolio was expecting all files to be images as this was the only supported option at the time. Since then Zenfolio has added support for uploading non-image files to the raw endpoint.

This PR fixes this issue by switching to using `mime_content_type()` to get the file type.

Fixes https://github.com/lildude/phpZenfolio/issues/23